### PR TITLE
go.work/go.mod: lowering golang version

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,4 +1,6 @@
-go 1.23.3
+go 1.21.0
+
+toolchain go1.21.0
 
 use (
 	.

--- a/internal/example_export/go.mod
+++ b/internal/example_export/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/logging/internal/example_export
 
-go 1.23.3
+go 1.21
 
 replace github.com/osbuild/logging => ../..
 

--- a/internal/example_journal/go.mod
+++ b/internal/example_journal/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/logging/internal/example_journal
 
-go 1.23.3
+go 1.21
 
 replace github.com/osbuild/logging => ../..
 

--- a/internal/example_logrus/go.mod
+++ b/internal/example_logrus/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/logging/internal/example_logrus
 
-go 1.23.3
+go 1.21
 
 replace github.com/osbuild/logging => ../..
 

--- a/internal/example_print/go.mod
+++ b/internal/example_print/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/logging/internal/example_print
 
-go 1.23.3
+go 1.21
 
 replace github.com/osbuild/logging => ../..
 

--- a/internal/example_sinit/go.mod
+++ b/internal/example_sinit/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/logging/internal/example_sinit
 
-go 1.23.3
+go 1.21
 
 replace github.com/osbuild/logging => ../..
 

--- a/internal/example_splunk/go.mod
+++ b/internal/example_splunk/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/logging/internal/example_splunk
 
-go 1.23.3
+go 1.21
 
 replace github.com/osbuild/logging => ../..
 

--- a/internal/example_web/go.mod
+++ b/internal/example_web/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/logging/internal/example_web
 
-go 1.23.3
+go 1.21
 
 replace github.com/osbuild/logging => ../..
 


### PR DESCRIPTION
Aligning the minimum required golang version with the other osbuild project's modules/repositories.