### PR TITLE
Fix tests in race mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ help:
 
 .PHONY: unit-tests
 unit-tests:  ## Run all tests
-	go test -v -covermode=atomic -coverprofile=coverage.txt ./...
+	go test -race -v -covermode=atomic -coverprofile=coverage.txt ./...
 
 .PHONY: lint
 lint:  ## run linter / static checker

--- a/pkg/splunk/client.go
+++ b/pkg/splunk/client.go
@@ -72,7 +72,7 @@ type Stats struct {
 	LastRequestDuration time.Duration
 }
 
-func newSplunkLogger(ctx context.Context, url, token, source, hostname string) *splunkLogger {
+func newSplunkLogger(ctx context.Context, url, token, source, hostname string, payloadsChannelSize int, maximumSize int, sendFrequency time.Duration) *splunkLogger {
 	rcl := retryablehttp.NewClient()
 
 	sl := &splunkLogger{
@@ -81,9 +81,9 @@ func newSplunkLogger(ctx context.Context, url, token, source, hostname string) *
 		token:               token,
 		source:              source,
 		hostname:            hostname,
-		payloadsChannelSize: DefaultPayloadsChannelSize,
-		maximumSize:         DefaultMaximumSize,
-		sendFrequency:       DefaultSendFrequency,
+		payloadsChannelSize: payloadsChannelSize,
+		maximumSize:         maximumSize,
+		sendFrequency:       sendFrequency,
 		pool: sync.Pool{
 			New: func() any {
 				buf := &bytes.Buffer{}

--- a/pkg/splunk/client_test.go
+++ b/pkg/splunk/client_test.go
@@ -55,7 +55,7 @@ func TestSplunkLoggerRetry(t *testing.T) {
 		ch <- true
 	}))
 
-	sl := newSplunkLogger(context.Background(), srv.URL, "token", "source", "hostname")
+	sl := newSplunkLogger(context.Background(), srv.URL, "token", "source", "hostname", DefaultPayloadsChannelSize, DefaultMaximumSize, DefaultSendFrequency)
 	_, err := sl.event([]byte("{}\n"))
 	if err != nil {
 		t.Error(err)
@@ -98,7 +98,7 @@ func TestSplunkLoggerContext(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	defer cancel()
-	sl := newSplunkLogger(ctx, srv.URL, "token", "source", "hostname")
+	sl := newSplunkLogger(ctx, srv.URL, "token", "source", "hostname", DefaultPayloadsChannelSize, DefaultMaximumSize, DefaultSendFrequency)
 	_, err := sl.event([]byte("{}\n"))
 	if err != nil {
 		t.Error(err)
@@ -120,7 +120,7 @@ func TestSplunkLoggerPayloads(t *testing.T) {
 		{
 			name: "empty",
 			f: func() error {
-				sl := newSplunkLogger(context.Background(), url, "token", "source", "hostname")
+				sl := newSplunkLogger(context.Background(), url, "token", "source", "hostname", DefaultPayloadsChannelSize, DefaultMaximumSize, DefaultSendFrequency)
 				defer sl.close()
 				_, err := sl.event([]byte("{}\n"))
 				if err != nil {
@@ -141,7 +141,7 @@ func TestSplunkLoggerPayloads(t *testing.T) {
 		{
 			name: "json",
 			f: func() error {
-				sl := newSplunkLogger(context.Background(), url, "token", "source", "hostname")
+				sl := newSplunkLogger(context.Background(), url, "token", "source", "hostname", DefaultPayloadsChannelSize, DefaultMaximumSize, DefaultSendFrequency)
 				defer sl.close()
 				_, err := sl.event([]byte(`{"a": "b"}` + "\n"))
 				if err != nil {

--- a/pkg/splunk/handler.go
+++ b/pkg/splunk/handler.go
@@ -38,7 +38,23 @@ func replaceAttr(groups []string, a slog.Attr) slog.Attr {
 func NewSplunkHandler(ctx context.Context, level slog.Level, url, token, source, hostname string) *SplunkHandler {
 	h := &SplunkHandler{
 		level:  level,
-		splunk: newSplunkLogger(ctx, url, token, source, hostname),
+		splunk: newSplunkLogger(ctx, url, token, source, hostname, DefaultPayloadsChannelSize, DefaultMaximumSize, DefaultSendFrequency),
+	}
+
+	h.jh = slog.NewJSONHandler(h, &slog.HandlerOptions{Level: level, AddSource: true, ReplaceAttr: replaceAttr})
+	return h
+}
+
+func newSplunkHandlerWithParams(
+	ctx context.Context,
+	level slog.Level,
+	url, token, source, hostname string,
+	maximumSize int,
+	payloadsChannelSize int,
+	sendFrequency time.Duration) *SplunkHandler {
+	h := &SplunkHandler{
+		level:  level,
+		splunk: newSplunkLogger(ctx, url, token, source, hostname, payloadsChannelSize, maximumSize, sendFrequency),
 	}
 
 	h.jh = slog.NewJSONHandler(h, &slog.HandlerOptions{Level: level, AddSource: true, ReplaceAttr: replaceAttr})

--- a/pkg/splunk/handler_test.go
+++ b/pkg/splunk/handler_test.go
@@ -33,6 +33,9 @@ func TestSplunkHandler(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	// largeString to fill up DefaultEventSize
+	largeString := strings.Repeat("X", DefaultEventSize)
+
 	tests := []struct {
 		name        string
 		f           func(*slog.Logger)
@@ -78,6 +81,20 @@ func TestSplunkHandler(t *testing.T) {
 			f: func(l *slog.Logger) {
 				for i := 0; i < 10; i++ {
 					l.Debug("m", "i", i)
+					//FIXME There shouldn't be a sleep necessary to flush for a new batch?
+					time.Sleep(DefaultSendFrequency + time.Millisecond*10)
+				}
+			},
+			maxChanSize: DefaultPayloadsChannelSize,
+			maxBufSize:  1,
+			events:      10,
+			batches:     10,
+		},
+		{
+			name: "10 large batches",
+			f: func(l *slog.Logger) {
+				for i := 0; i < 10; i++ {
+					l.Debug(largeString, "i", i)
 					//FIXME There shouldn't be a sleep necessary to flush for a new batch?
 					time.Sleep(DefaultSendFrequency + time.Millisecond*10)
 				}

--- a/pkg/splunk/handler_test.go
+++ b/pkg/splunk/handler_test.go
@@ -90,9 +90,7 @@ func TestSplunkHandler(t *testing.T) {
 		t.Run(fmt.Sprintf("%v", tt.name), func(t *testing.T) {
 			emptyLines = 0
 
-			h := NewSplunkHandler(context.Background(), slog.LevelDebug, srv.URL, "", "s", "h")
-			h.splunk.payloadsChannelSize = tt.maxChanSize
-			h.splunk.maximumSize = tt.maxBufSize
+			h := newSplunkHandlerWithParams(context.Background(), slog.LevelDebug, srv.URL, "", "s", "h", tt.maxChanSize, tt.maxBufSize, DefaultSendFrequency)
 			logger := slog.New(h)
 			tt.f(logger)
 			h.Close()
@@ -131,8 +129,7 @@ func TestSplunkHandlerBatching(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	h := NewSplunkHandler(context.Background(), slog.LevelDebug, srv.URL, "", "s", "h")
-	h.splunk.maximumSize = 1000
+	h := newSplunkHandlerWithParams(context.Background(), slog.LevelDebug, srv.URL, "", "s", "h", DefaultPayloadsChannelSize, 1000, DefaultSendFrequency)
 	logger := slog.New(h).WithGroup("g").With("kg1", "kv1")
 
 	for i := 0; i < 4000; i++ {

--- a/pkg/splunk/handler_test.go
+++ b/pkg/splunk/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSplunkHandler(t *testing.T) {
@@ -77,6 +78,8 @@ func TestSplunkHandler(t *testing.T) {
 			f: func(l *slog.Logger) {
 				for i := 0; i < 10; i++ {
 					l.Debug("m", "i", i)
+					//FIXME There shouldn't be a sleep necessary to flush for a new batch?
+					time.Sleep(DefaultSendFrequency + time.Millisecond*10)
 				}
 			},
 			maxChanSize: DefaultPayloadsChannelSize,


### PR DESCRIPTION
@lzap I tried to fix two problems with the tests in `-race` mode.
First is pretty straight forward (don't change a class value when the go function is already running).
The second, I need your input why there are the `time.Sleep(DefaultSendFrequency + time.Millisecond*10)` "needed" to get the tests working?

Can you reproduce? (remove the sleeps and see the `make unit-tests` failing)

Setting to draft now, because there shouldn't be sleeps in the tests.