### PR TITLE
tests: add more tests to splunk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ help:
 
 .PHONY: unit-tests
 unit-tests:  ## Run all tests
-	go test -v -covermode=atomic -coverprofile=coverage.txt ./...
+	go test -race -v -covermode=atomic -coverprofile=coverage.txt ./...
 
 .PHONY: lint
 lint:  ## run linter / static checker
@@ -20,4 +20,3 @@ lint:  ## run linter / static checker
 .PHONY: coverage-report
 coverage-report: unit-tests  ## Run unit tests and generate an HTML coverage report
 	go tool cover -o coverage.html -html coverage.txt
-

--- a/internal/example_splunk/main.go
+++ b/internal/example_splunk/main.go
@@ -24,9 +24,16 @@ func main() {
 	if !ok {
 		url = srv.URL
 	}
-	token, ok := os.LookupEnv("SPLUNK_TOKEN")
+	token := os.Getenv("SPLUNK_TOKEN")
 
-	h := splunk.NewSplunkHandler(context.Background(), slog.LevelDebug, url, token, "source", "hostname")
+	c := splunk.SplunkConfig{
+		Level:    slog.LevelDebug,
+		URL:      url,
+		Token:    token,
+		Source:   "source",
+		Hostname: "hostname",
+	}
+	h := splunk.NewSplunkHandler(context.Background(), c)
 
 	log := slog.New(h)
 	log.Debug("message", "k1", "v1")

--- a/pkg/sinit/init.go
+++ b/pkg/sinit/init.go
@@ -173,13 +173,14 @@ func InitializeLogging(ctx context.Context, config LoggingConfig) error {
 		}
 
 		if config.SplunkConfig.Enabled {
-			handlerSplunk = splunk.NewSplunkHandler(ctx,
-				parseLevel(config.SplunkConfig.Level),
-				config.SplunkConfig.URL,
-				config.SplunkConfig.Token,
-				config.SplunkConfig.Source,
-				config.SplunkConfig.Hostname,
-			)
+			c := splunk.SplunkConfig{
+				Level:    parseLevel(config.SplunkConfig.Level),
+				URL:      config.SplunkConfig.URL,
+				Token:    config.SplunkConfig.Token,
+				Source:   config.SplunkConfig.Source,
+				Hostname: config.SplunkConfig.Hostname,
+			}
+			handlerSplunk = splunk.NewSplunkHandler(ctx, c)
 			handlers = append(handlers, handlerSplunk)
 		}
 

--- a/pkg/splunk/client_test.go
+++ b/pkg/splunk/client_test.go
@@ -55,7 +55,7 @@ func TestSplunkLoggerRetry(t *testing.T) {
 		ch <- true
 	}))
 
-	sl := newSplunkLogger(context.Background(), srv.URL, "token", "source", "hostname")
+	sl := newSplunkLogger(context.Background(), srv.URL, "token", "source", "hostname", 0)
 	_, err := sl.event([]byte("{}\n"))
 	if err != nil {
 		t.Error(err)
@@ -98,7 +98,7 @@ func TestSplunkLoggerContext(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	defer cancel()
-	sl := newSplunkLogger(ctx, srv.URL, "token", "source", "hostname")
+	sl := newSplunkLogger(ctx, srv.URL, "token", "source", "hostname", 0)
 	_, err := sl.event([]byte("{}\n"))
 	if err != nil {
 		t.Error(err)
@@ -120,7 +120,7 @@ func TestSplunkLoggerPayloads(t *testing.T) {
 		{
 			name: "empty",
 			f: func() error {
-				sl := newSplunkLogger(context.Background(), url, "token", "source", "hostname")
+				sl := newSplunkLogger(context.Background(), url, "token", "source", "hostname", 0)
 				defer sl.close()
 				_, err := sl.event([]byte("{}\n"))
 				if err != nil {
@@ -141,7 +141,7 @@ func TestSplunkLoggerPayloads(t *testing.T) {
 		{
 			name: "json",
 			f: func() error {
-				sl := newSplunkLogger(context.Background(), url, "token", "source", "hostname")
+				sl := newSplunkLogger(context.Background(), url, "token", "source", "hostname", 0)
 				defer sl.close()
 				_, err := sl.event([]byte(`{"a": "b"}` + "\n"))
 				if err != nil {


### PR DESCRIPTION
I started adding integration `slogtest.Run` test (only available in Go 1.22+) that executes variety of contract tests against a handler covering various hidden dragons of handlers. While I was working on it, I noticed how ugly those parameters accessed by tests are and it was actually a racey code, tho only used for testing so it was harmless.

So I removed it and prepared it for a new test which I commented out in this draft so you can see what is different. I haven’t spotted it yet.