### PR TITLE
refactor: improve build commit id and add time

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,10 @@ go run github.com/osbuild/logging/internal/example_web/
 To customize the `build_id` value added to all logs for non-git builds (e.g. in an RPM build), do:
 
 ```
-go build -ldflags="-X 'github.com/osbuild/logging.BuildCustom=1234567'" github.com/osbuild/logging/internal/example_web/
+go build \
+	-ldflags="-X 'github.com/osbuild/logging.buildCommit=1234567'" \
+	-ldflags="-X 'github.com/osbuild/logging.buildTime=$(date -u)'" \
+	github.com/osbuild/logging/internal/example_web/
 ```
 
 ## Running tests:

--- a/internal/example_print/main.go
+++ b/internal/example_print/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func subProcess(ctx context.Context) {
-	span, ctx := strc.Start(ctx, "subProcess")
+	span, _ := strc.Start(ctx, "subProcess")
 	defer span.End()
 
 	span.Event("an event")

--- a/internal/example_web/main.go
+++ b/internal/example_web/main.go
@@ -21,7 +21,7 @@ func cleaner(groups []string, a slog.Attr) slog.Attr {
 }
 
 func subProcess(ctx context.Context) {
-	span, ctx := strc.Start(ctx, "subProcess")
+	span, _ := strc.Start(ctx, "subProcess")
 	defer span.End()
 
 	span.Event("an event")

--- a/runtime.go
+++ b/runtime.go
@@ -8,11 +8,13 @@ const (
 )
 
 var (
-	// BuildCommit is the git source commit (only first BuildCommitChars characters)
-	BuildCommit string
+	// buildCommit is the git source commit (only first BuildCommitChars characters).
+	// Use linker flag to customize it: -X 'github.com/osbuild/logging.buildCommit=1234567
+	buildCommit string
 
-	// BuildCustom overrides the build commit with a custom string
-	BuildCustom string
+	// buildTime is the build time, if VCS is available
+	// Use linker flag to customize it: -X 'github.com/osbuild/logging.buildTime=2021-01-01T00:00:00Z'
+	buildTime string
 )
 
 func init() {
@@ -21,16 +23,22 @@ func init() {
 			switch bs.Key {
 			case "vcs.revision":
 				if len(bs.Value) > BuildCommitChars {
-					BuildCommit = bs.Value[0:BuildCommitChars]
+					buildCommit = bs.Value[0:BuildCommitChars]
 				}
+			case "vcs.time":
+				buildTime = bs.Value
 			}
 		}
 	}
 }
 
+// BuildID returns the build ID, typically a git commit but can be overriden via a linker flag.
+// This is the short version, up to BuildCommitChars characters long.
 func BuildID() string {
-	if BuildCustom != "" {
-		return BuildCustom
-	}
-	return BuildCommit
+	return buildCommit
+}
+
+// BuildTime returns the build time, if available.
+func BuildTime() string {
+	return buildTime
 }


### PR DESCRIPTION
The variables were exported, I thought it is necessary in order for the linker to reach them. Funny, huh? :-) I removed them and simplified it. Also added time, it was in the image-builder previously so maybe we want to keep it.

The branch name contains a `¨` character which I hit quite often by accidend, I use Czech layout, yeah. I guess we can rebase-merge and delete and it will not be recorded anywhere in the git log for life?!?