### PR TITLE
collect: move to the `package <pkg>_test` pattern in the test

### DIFF
--- a/pkg/collect/buffer_handler_test.go
+++ b/pkg/collect/buffer_handler_test.go
@@ -1,15 +1,17 @@
-package collect
+package collect_test
 
 import (
 	"encoding/json"
 	"log/slog"
 	"testing"
 	"testing/slogtest"
+
+	"github.com/osbuild/logging/pkg/collect"
 )
 
 func TestStandardLibraryHelper(t *testing.T) {
 	var result []map[string]any
-	th := NewTestHandler(slog.LevelDebug, true, true, true)
+	th := collect.NewTestHandler(slog.LevelDebug, true, true, true)
 	err := slogtest.TestHandler(th, func() []map[string]any {
 		result = th.All()
 		return parseLogEntries(t, result)


### PR DESCRIPTION
This (trivial) commit moves the test to be `package collect_test` to follow what (a lot of) the standard library is doing to encourage testing of the API surface.