### PR TITLE
fix: return callback type instead anon func

### DIFF
--- a/pkg/strc/middleware_ctx.go
+++ b/pkg/strc/middleware_ctx.go
@@ -28,7 +28,7 @@ func HeadfieldPairMiddleware(pairs []HeadfieldPair) func(http.Handler) http.Hand
 }
 
 // HeadfieldPairCallback is a slog callback that extracts values from the context and adds them to the attributes.
-func HeadfieldPairCallback(pairs []HeadfieldPair) func(context.Context, []slog.Attr) ([]slog.Attr, error) {
+func HeadfieldPairCallback(pairs []HeadfieldPair) MultiCallback {
 	return func(ctx context.Context, a []slog.Attr) ([]slog.Attr, error) {
 		for _, p := range pairs {
 			if value, ok := ctx.Value(p).(string); ok {


### PR DESCRIPTION
A small change which returns a function type instead of anonymous function. Nicer code on the caller side.