### PR TITLE
feat: add NoTraceContext middleware config

### DIFF
--- a/pkg/strc/middleware_test.go
+++ b/pkg/strc/middleware_test.go
@@ -233,6 +233,27 @@ func TestMiddlewareAddsToContext(t *testing.T) {
 	middleware(handler).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
 }
 
+func TestMiddlewareDoesNotAddToContext(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	middleware := strc.NewMiddlewareWithConfig(logger, strc.MiddlewareConfig{
+		NoTraceContext: true,
+	})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tid := strc.TraceIDFromContext(r.Context())
+		sid := strc.SpanIDFromContext(r.Context())
+
+		if tid != strc.EmptyTraceID {
+			t.Errorf("expected trace id to by empty")
+		}
+
+		if sid != strc.EmptySpanID {
+			t.Errorf("expected span id to be empty")
+		}
+	})
+
+	middleware(handler).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
+}
+
 func TestMiddlewareAddsTraceCtxAndHeaders(t *testing.T) {
 	var tid strc.TraceID
 

--- a/pkg/strc/stgraph/builder.go
+++ b/pkg/strc/stgraph/builder.go
@@ -105,7 +105,7 @@ func (b *TraceBuilder) Process(r io.Reader, w io.Writer, format string) error {
 		rdy := b.Window.Append(&span)
 		if rdy {
 			spans := b.Window.Pop(span.TraceID)
-			if spans == nil || len(spans) < 1 {
+			if len(spans) < 1 {
 				return fmt.Errorf("empty trace: %s", span.TraceID)
 			}
 


### PR DESCRIPTION
The middleware in `strc` library provides both logging capabilities (when a request finishes, optional headers, optional debug body, filtering) as well as extracting trace id and putting it into the context.

This patch adds optional flag `NoTraceContext` which causes to not to put trace/span into the context. This will be usedful in `image-builder-crc` where we want to do rollout with two phases:

* Phase 1: transition from logrus, no tracing
* Phase 2: add tracing, context handling and pass over to HTTP clients

@croissanne 