### PR TITLE
fix: log custom span arguments

### DIFF
--- a/pkg/strc/exporter_test.go
+++ b/pkg/strc/exporter_test.go
@@ -171,6 +171,7 @@ func TestTraceExporterPC(t *testing.T) {
 			},
 			skipSource: true,
 			want: []slog.Attr{
+				slog.Group("span", "k1", "v1"),
 				slog.Group("span", "name", "process"),
 				slog.Group("span", "id", "IvQORsV"),
 				slog.Group("span", "parent", "0000000"),
@@ -190,6 +191,7 @@ func TestTraceExporterPC(t *testing.T) {
 				slog.Group("span", "parent", "IvQORsV"),
 				slog.Group("span", "trace", "bqzcRlJahlbbBZH"),
 				slog.Group("span", "dur", "0s"),
+				slog.Group("span", "k1", "v1"),
 				slog.Group("span", "name", "process"),
 				slog.Group("span", "id", "IvQORsV"),
 				slog.Group("span", "parent", "0000000"),
@@ -203,6 +205,7 @@ func TestTraceExporterPC(t *testing.T) {
 				process(context.Background())
 			},
 			want: []slog.Attr{
+				slog.Group("span", "k1", "v1"),
 				slog.Group("span", "name", "process"),
 				slog.Group("span", "id", "IvQORsV"),
 				slog.Group("span", "parent", "0000000"),
@@ -226,6 +229,7 @@ func TestTraceExporterPC(t *testing.T) {
 				slog.Group("span", "trace", "bqzcRlJahlbbBZH"),
 				slog.Group("span", "dur", "0s"),
 				slog.Group("span", "source", "exporter_test.go:0"),
+				slog.Group("span", "k1", "v1"),
 				slog.Group("span", "name", "process"),
 				slog.Group("span", "id", "IvQORsV"),
 				slog.Group("span", "parent", "0000000"),
@@ -241,6 +245,7 @@ func TestTraceExporterPC(t *testing.T) {
 			},
 			includeTime: true,
 			want: []slog.Attr{
+				slog.Group("span", "k1", "v1"),
 				slog.Group("span", "name", "process"),
 				slog.Group("span", "id", "IvQORsV"),
 				slog.Group("span", "parent", "0000000"),
@@ -268,6 +273,7 @@ func TestTraceExporterPC(t *testing.T) {
 				slog.Group("span", "dur", "0s"),
 				slog.Group("span", "source", "exporter_test.go:0"),
 				slog.Group("span", "time", tm),
+				slog.Group("span", "k1", "v1"),
 				slog.Group("span", "name", "process"),
 				slog.Group("span", "id", "IvQORsV"),
 				slog.Group("span", "parent", "0000000"),

--- a/pkg/strc/trace.go
+++ b/pkg/strc/trace.go
@@ -9,6 +9,7 @@ import (
 	"time"
 )
 
+// Level is the log level used for trace logging.
 var Level slog.Level = slog.LevelDebug
 
 // SpanGroupName is the group name used for span attributes.
@@ -32,10 +33,12 @@ func init() {
 	destination.Store(slog.New(&NoopHandler{}))
 }
 
+// SetLogger sets the logger for the package.
 func SetLogger(lg *slog.Logger) {
 	destination.Store(lg.WithGroup(SpanGroupName))
 }
 
+// SetNoopLogger sets a no-op logger for the package.
 func SetNoopLogger() {
 	destination.Store(slog.New(&NoopHandler{}))
 }
@@ -62,6 +65,14 @@ func callerPtr(skip int) string {
 	return file + ":" + fmt.Sprint(line)
 }
 
+// Start starts a new span with the given name and optional arguments. All arguments are present in
+// subsequent Event and End calls. Must call End to finish the span.
+//
+//	span, ctx := strc.Start(ctx, "calculating something big")
+//	defer span.End()
+//
+// It immediately logs a message with the span name, span information in SpanGroupName and optional
+// arguments.
 func Start(ctx context.Context, name string, args ...any) (*Span, context.Context) {
 	tid := TraceIDFromContext(ctx)
 	if tid == EmptyTraceID {
@@ -101,11 +112,19 @@ func Start(ctx context.Context, name string, args ...any) (*Span, context.Contex
 		attrs = append(attrs, slog.String(slog.SourceKey, callerPtr(2)))
 	}
 
-	logger().LogAttrs(ctx, Level, "span "+name+" started", attrs...)
+	logger := logger()
+	if len(args) > 0 {
+		logger = logger.With(args...)
+	}
+	logger.LogAttrs(ctx, Level, "span "+name+" started", attrs...)
 
 	return span, ctx
 }
 
+// Event logs a new event in the span with the given name and optional arguments.
+//
+// It immediately logs a message with the span name, span information in SpanGroupName and
+// optional arguments.
 func (s *Span) Event(name string, args ...any) {
 	if !logger().Enabled(s.ctx, Level) {
 		return
@@ -126,10 +145,22 @@ func (s *Span) Event(name string, args ...any) {
 		attrs = append(attrs, slog.String(slog.SourceKey, callerPtr(2)))
 	}
 
-	logger().LogAttrs(s.ctx, Level, "span "+s.name+" event "+name, attrs...)
+	logger := logger()
+	if len(s.args) > 0 {
+		logger = logger.With(s.args...)
+	}
+	if len(args) > 0 {
+		logger = logger.With(args...)
+	}
+	logger.LogAttrs(s.ctx, Level, "span "+s.name+" event "+name, attrs...)
 }
 
-func (s *Span) End() {
+// End finishes the span and logs the duration of the span. Optional arguments can be provided
+// to log additional information.
+//
+// It immediately logs a message with the span name, span information in SpanGroupName and
+// optional arguments.
+func (s *Span) End(args ...any) {
 	if !logger().Enabled(s.ctx, Level) {
 		return
 	}
@@ -149,5 +180,12 @@ func (s *Span) End() {
 		attrs = append(attrs, slog.String(slog.SourceKey, callerPtr(2)))
 	}
 
-	logger().LogAttrs(s.ctx, Level, fmt.Sprintf("span %s finished in %v", s.name, dur), attrs...)
+	logger := logger()
+	if len(s.args) > 0 {
+		logger = logger.With(s.args...)
+	}
+	if len(args) > 0 {
+		logger = logger.With(args...)
+	}
+	logger.LogAttrs(s.ctx, Level, fmt.Sprintf("span %s finished in %v", s.name, dur), attrs...)
 }

--- a/pkg/strc/trace_test.go
+++ b/pkg/strc/trace_test.go
@@ -39,14 +39,14 @@ func TestLogTextHandler(t *testing.T) {
 		buf.Reset()
 	}
 
-	s, ctx := Start(context.Background(), "test")
-	check(`time=? level=DEBUG msg="span test started" span.name=test span.id=IvQORsV span.parent=0000000 span.trace=bqzcRlJahlbbBZH span.source=?`)
+	s, ctx := Start(context.Background(), "test", "arg1", 1)
+	check(`time=? level=DEBUG msg="span test started" span.arg1=1 span.name=test span.id=IvQORsV span.parent=0000000 span.trace=bqzcRlJahlbbBZH span.source=?`)
 
-	s.Event("one")
-	check(`time=? level=DEBUG msg="span test event one" span.name=test span.id=IvQORsV span.parent=0000000 span.trace=bqzcRlJahlbbBZH span.event=one span.at=? span.source=?`)
+	s.Event("one", "arg2", 2)
+	check(`time=? level=DEBUG msg="span test event one" span.arg1=1 span.arg2=2 span.name=test span.id=IvQORsV span.parent=0000000 span.trace=bqzcRlJahlbbBZH span.event=one span.at=? span.source=?`)
 
-	s.End()
-	check(`time=? level=DEBUG msg="span ? finished in ?" span.name=test span.id=IvQORsV span.parent=0000000 span.trace=bqzcRlJahlbbBZH span.dur=? span.source=?`)
+	s.End("arg3", 3)
+	check(`time=? level=DEBUG msg="span ? finished in ?" span.arg1=1 span.arg3=3 span.name=test span.id=IvQORsV span.parent=0000000 span.trace=bqzcRlJahlbbBZH span.dur=? span.source=?`)
 
 	s, _ = Start(ctx, "level1")
 	check(`time=? level=DEBUG msg="span level1 started" span.name=level1 span.id=kYcTpgn span.parent=IvQORsV span.trace=bqzcRlJahlbbBZH span.source=?`)


### PR DESCRIPTION
When working on pgx tracing I noticed that trace custom arguments are not logged. Fixed this, added optional arguments to the `End` function which is useful for pgx specifically. Updated tests. @ezr-ondrej 