### PR TITLE
logrus: exit on fatal error

### DIFF
--- a/internal/example_web/main.go
+++ b/internal/example_web/main.go
@@ -105,7 +105,7 @@ func main() {
 	slog.SetDefault(logger)
 	strc.SetLogger(logger)
 	strc.SkipSource = true // for better readability
-	logrus.SetDefault(logrus.NewProxyFor(logger))
+	logrus.SetDefault(logrus.NewProxyFor(logger, false))
 
 	s1, s2, s3 := startServers(logger)
 	defer s1.Close()

--- a/pkg/logrus/README.md
+++ b/pkg/logrus/README.md
@@ -2,6 +2,8 @@
 
 A temporary `logrus` proxy to `log/slog`. Only used for the transition period until our projects are fully migrated. Please keep in mind this is an incomplete implementation, only functions used in osbuild projects are present.
 
+By default, the proxy does not exit on `Fatal` or panic on `Panic` calls, this needs to be explicitly enabled via argument in `logrus.NewProxyFor` function.
+
 ### How to use
 
 ```go

--- a/pkg/logrus/proxy_test.go
+++ b/pkg/logrus/proxy_test.go
@@ -232,7 +232,7 @@ func TestLogrusProxy(t *testing.T) {
 
 	ch := collect.NewTestHandler(slog.LevelDebug, false, false, false)
 	logger := slog.New(ch)
-	p := NewProxyFor(logger)
+	p := NewProxyFor(logger, false)
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("t-%d", i), func(t *testing.T) {
@@ -249,7 +249,7 @@ func TestLogrusProxy(t *testing.T) {
 func TestLogrusProxyFuncs(t *testing.T) {
 	ch := collect.NewTestHandler(slog.LevelDebug, false, false, false)
 	logger := slog.New(ch)
-	SetDefault(NewProxyFor(logger))
+	SetDefault(NewProxyFor(logger, false))
 	defer SetDefault(nil)
 
 	Traceln("trace")

--- a/pkg/sinit/init.go
+++ b/pkg/sinit/init.go
@@ -34,6 +34,8 @@ type LoggingConfig struct {
 	SentryConfig SentryConfig
 
 	TracingConfig TracingConfig
+
+	LogrusConfig LogrusConfig
 }
 
 // StdoutConfig is the configuration for the standard output.
@@ -130,6 +132,17 @@ type TracingConfig struct {
 	// ContextCallback is an optional callback function that is called for each log entry
 	// to add additional attributes to the log entry.
 	ContextCallback strc.MultiCallback
+}
+
+// LogrusConfig is the configuration for the logrus proxy.
+type LogrusConfig struct {
+	// Enabled is a flag to enable logrus proxy.
+	Enabled bool
+
+	// ExitOnFatal is a flag to enable exiting the process on fatal log entries.
+	// If set to true, the process will exit with status code 1 on fatal log entries as
+	// wel as panic log entries.
+	ExitOnFatal bool
 }
 
 var initOnce sync.Once
@@ -246,7 +259,9 @@ func InitializeLogging(ctx context.Context, config LoggingConfig) error {
 		}
 
 		// configure logrus proxy
-		logrus.SetDefault(logrus.NewProxyFor(logger))
+		if config.LogrusConfig.Enabled {
+			logrus.SetDefault(logrus.NewProxyFor(logger, config.LogrusConfig.ExitOnFatal))
+		}
 	})
 
 	return outerError


### PR DESCRIPTION
The proxy logger now supports an option to exit the process on fatal errors and panic on panic calls. This is useful for applications that need to ensure immediate termination on critical errors.

Previously it was enabled by default, this now changes and it must be explicitly enabled via configuration.

---

Closes: https://github.com/osbuild/logging/issues/23

For the record, this is an API breaking change, but the library is only used by CRC now and it was fully migrated from `logrus` therefore actually it proxy is not needed anymore.