### PR TITLE
sinit: stdlib log package proxy

### DIFF
--- a/internal/example_sinit/main.go
+++ b/internal/example_sinit/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log"
 	"log/slog"
 	"os"
 	"time"
@@ -12,6 +13,10 @@ import (
 
 func main() {
 	cfg := sinit.LoggingConfig{
+		StdlibLogConfig: sinit.StdlibLogConfig{
+			Enabled: true,
+			Level:   slog.LevelDebug,
+		},
 		StdoutConfig: sinit.StdoutConfig{
 			Enabled: true,
 			Level:   "debug",
@@ -64,6 +69,8 @@ func main() {
 	)
 
 	slog.ErrorContext(ctx, "an error occured", "err", "this is an error")
+
+	log.Println("This is a log message from the standard library logger")
 
 	span.End()
 }

--- a/pkg/sinit/init.go
+++ b/pkg/sinit/init.go
@@ -23,6 +23,8 @@ import (
 
 // LoggingConfig is the configuration for the logging system.
 type LoggingConfig struct {
+	StdlibLogConfig StdlibLogConfig
+
 	StdoutConfig StdoutConfig
 
 	JournalConfig JournalConfig
@@ -34,6 +36,20 @@ type LoggingConfig struct {
 	SentryConfig SentryConfig
 
 	TracingConfig TracingConfig
+}
+
+// StdlibLogConfig is the configuration for the proxy of the standard library logger. When enabled, all
+// log entries written to the standard library log package will be forwarded to the slog logger.
+// Use log.Writer() to get a standard library writer when needed.
+type StdlibLogConfig struct {
+	// Enabled is a flag to enable the standard library logger proxy.
+	Enabled bool
+
+	// Level to use when writing to the standard library logger. Info by default.
+	Level slog.Level
+
+	// Flags for the standard logger set via SetFlags
+	Flags int
 }
 
 // StdoutConfig is the configuration for the standard output.
@@ -243,6 +259,14 @@ func InitializeLogging(ctx context.Context, config LoggingConfig) error {
 		// configure tracing
 		if config.TracingConfig.Enabled {
 			strc.SetLogger(logger)
+		}
+
+		// configure standard library logger
+		if config.StdlibLogConfig.Enabled {
+			logger := slog.NewLogLogger(handlerMulti, slog.LevelDebug)
+			writer := &logLoggerWriter{dest: logger}
+			log.SetFlags(config.StdlibLogConfig.Flags)
+			log.SetOutput(writer)
 		}
 
 		// configure logrus proxy

--- a/pkg/sinit/writer.go
+++ b/pkg/sinit/writer.go
@@ -1,0 +1,21 @@
+package sinit
+
+import (
+	"errors"
+	"log"
+)
+
+type logLoggerWriter struct {
+	dest *log.Logger
+}
+
+var ErrLoggerNotInitialized = errors.New("log logger is not initialized")
+
+func (w *logLoggerWriter) Write(p []byte) (n int, err error) {
+	if w.dest == nil {
+		return 0, ErrLoggerNotInitialized
+	}
+
+	w.dest.Output(2, string(p))
+	return len(p), nil
+}


### PR DESCRIPTION
It is useful to be able to use the standard library log package in applications that use slog. This commit adds a proxy for the standard library logger that forwards all log entries to the slog logger.

---

Closes: https://github.com/osbuild/logging/issues/22

This is useful for composer which configures the standard library logger.