### PR TITLE
[RFC] sinit: add (failing) test that ensures init twice errors

### DIFF
--- a/pkg/sinit/init_test.go
+++ b/pkg/sinit/init_test.go
@@ -48,3 +48,18 @@ func TestValidationSplunkURLInvalid(t *testing.T) {
 		t.Fatalf("expected ErrInvalidURL error, got %v", err)
 	}
 }
+
+func TestInitLoggingRunTwice(t *testing.T) {
+	ctx := context.Background()
+	cfg := LoggingConfig{
+		SplunkConfig: SplunkConfig{
+			Enabled: true,
+		},
+	}
+	err := InitializeLogging(ctx, cfg)
+	assert.NoError(t, err)
+
+	// this should now error
+	err = InitializeLogging(ctx, LoggingConfig{})
+	assert.EqualError(t, err, "already initialized")
+}

--- a/pkg/sinit/init_test.go
+++ b/pkg/sinit/init_test.go
@@ -1,0 +1,50 @@
+package sinit
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestEmptyConfiguration(t *testing.T) {
+	ctx := context.Background()
+	cfg := LoggingConfig{}
+	err := InitializeLogging(ctx, cfg)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidationEmpty(t *testing.T) {
+	cfg := LoggingConfig{}
+
+	if err := validate(cfg); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidationSplunkURLValid(t *testing.T) {
+	cfg := LoggingConfig{
+		SplunkConfig: SplunkConfig{
+			Enabled: true,
+			URL:     "https://splunk.example.com",
+		},
+	}
+
+	if err := validate(cfg); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidationSplunkURLInvalid(t *testing.T) {
+	cfg := LoggingConfig{
+		SplunkConfig: SplunkConfig{
+			Enabled: true,
+			URL:     "%zzzzz",
+		},
+	}
+
+	if err := validate(cfg); !errors.Is(err, ErrInvalidURL) {
+		t.Fatalf("expected ErrInvalidURL error, got %v", err)
+	}
+}


### PR DESCRIPTION
[RFC as its documented behavior but I still think we should change it]

This commit adds a test that ensures that when `InitializeLogging`
is called twice there is an error. The current implementation
is using a `sync.Once()` so init will only have an effect.

It is document that subsequent calls have no effect but still
I think we need to error, I don't see a use-case where init
with a changed configuration again would not warant an error.

