### PR TITLE
sinit: add (failing) test that ensures that unset URL errors

### DIFF
--- a/pkg/sinit/init_test.go
+++ b/pkg/sinit/init_test.go
@@ -1,0 +1,50 @@
+package sinit
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestEmptyConfiguration(t *testing.T) {
+	ctx := context.Background()
+	cfg := LoggingConfig{}
+	err := InitializeLogging(ctx, cfg)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidationEmpty(t *testing.T) {
+	cfg := LoggingConfig{}
+
+	if err := validate(cfg); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidationSplunkURLValid(t *testing.T) {
+	cfg := LoggingConfig{
+		SplunkConfig: SplunkConfig{
+			Enabled: true,
+			URL:     "https://splunk.example.com",
+		},
+	}
+
+	if err := validate(cfg); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidationSplunkURLInvalid(t *testing.T) {
+	cfg := LoggingConfig{
+		SplunkConfig: SplunkConfig{
+			Enabled: true,
+			URL:     "%zzzzz",
+		},
+	}
+
+	if err := validate(cfg); !errors.Is(err, ErrInvalidURL) {
+		t.Fatalf("expected ErrInvalidURL error, got %v", err)
+	}
+}

--- a/pkg/sinit/init_test.go
+++ b/pkg/sinit/init_test.go
@@ -48,3 +48,15 @@ func TestValidationSplunkURLInvalid(t *testing.T) {
 		t.Fatalf("expected ErrInvalidURL error, got %v", err)
 	}
 }
+
+func TestValidationSplunkEmptyURL(t *testing.T) {
+	cfg := LoggingConfig{
+		SplunkConfig: SplunkConfig{
+			Enabled: true,
+		},
+	}
+
+	if err := validate(cfg); !errors.Is(err, ErrInvalidURL) {
+		t.Fatalf("expected ErrInvalidURL error, got %v", err)
+	}
+}


### PR DESCRIPTION
[please just close if I misunderstand how splunk works and there is a use-case to enable it without a URL] 

This commit adds a test that ensures that an empty URL
for splunk errors. Given that splunk is only functional
when a URL is set and that config cannot changed after
init it seems we need to error here (we do not currently).
