### PR TITLE
init: fix race in Flush()

### DIFF
--- a/pkg/sinit/init.go
+++ b/pkg/sinit/init.go
@@ -146,6 +146,7 @@ type LogrusConfig struct {
 }
 
 var initOnce sync.Once
+var flushMu sync.Mutex
 var handlerMulti *strc.MultiHandler
 var handlerSplunk *splunk.SplunkHandler
 var handlerCloudWatch *cloudwatchwriter2.Handler
@@ -271,6 +272,9 @@ func InitializeLogging(ctx context.Context, config LoggingConfig) error {
 
 // Flush flushes all pending logs to the configured outputs. Blocks until all logs are written.
 func Flush() {
+	flushMu.Lock()
+	defer flushMu.Unlock()
+
 	if handlerSplunk != nil {
 		handlerSplunk.Close()
 	}

--- a/pkg/sinit/init_test.go
+++ b/pkg/sinit/init_test.go
@@ -48,3 +48,20 @@ func TestValidationSplunkURLInvalid(t *testing.T) {
 		t.Fatalf("expected ErrInvalidURL error, got %v", err)
 	}
 }
+
+func TestValidationSplunkFlushRacy(t *testing.T) {
+	ctx := context.Background()
+	cfg := LoggingConfig{
+		SplunkConfig: SplunkConfig{
+			Enabled: true,
+			URL:     "http://example.com/splunk",
+		},
+	}
+	err := InitializeLogging(ctx, cfg)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	go Flush()
+	go Flush()
+}

--- a/pkg/sinit/init_test.go
+++ b/pkg/sinit/init_test.go
@@ -1,0 +1,50 @@
+package sinit
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestEmptyConfiguration(t *testing.T) {
+	ctx := context.Background()
+	cfg := LoggingConfig{}
+	err := InitializeLogging(ctx, cfg)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidationEmpty(t *testing.T) {
+	cfg := LoggingConfig{}
+
+	if err := validate(cfg); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidationSplunkURLValid(t *testing.T) {
+	cfg := LoggingConfig{
+		SplunkConfig: SplunkConfig{
+			Enabled: true,
+			URL:     "https://splunk.example.com",
+		},
+	}
+
+	if err := validate(cfg); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidationSplunkURLInvalid(t *testing.T) {
+	cfg := LoggingConfig{
+		SplunkConfig: SplunkConfig{
+			Enabled: true,
+			URL:     "%zzzzz",
+		},
+	}
+
+	if err := validate(cfg); !errors.Is(err, ErrInvalidURL) {
+		t.Fatalf("expected ErrInvalidURL error, got %v", err)
+	}
+}


### PR DESCRIPTION
The current code in `Flush()` is racy. This can be shown with
```console
$ go test -race -run TestValidationSplunkFlushRacy
PASS
panic: close of closed channel

goroutine 9 [running]:
github.com/osbuild/logging/pkg/splunk.(*splunkLogger).close(0xc00033c270)
        /home/mvogt/devel/osbuild/logging/pkg/splunk/client.go:233 +0x5a
github.com/osbuild/logging/pkg/splunk.(*SplunkHandler).Close(...)
        /home/mvogt/devel/osbuild/logging/pkg/splunk/handler.go:79
github.com/osbuild/logging/pkg/sinit.Flush()
        /home/mvogt/devel/osbuild/logging/pkg/sinit/init.go:275 +0x65
created by github.com/osbuild/logging/pkg/sinit.TestValidationSplunkFlushRacy in goroutine 7
        /home/mvogt/devel/osbuild/logging/pkg/sinit/init_test.go:65 +0x16b
exit status 2
FAIL    github.com/osbuild/logging/pkg/sinit    0.016s
```
It is hard to reproduce otherwise fwiw (i.e. without -race
or with -run).

There might be more issues in the lower layers but the check
for `handlerSplunk != nil` can be true for two go-routine
so they will both close the handlerSplunk (and same for
handleCloudwatch).

The fix might be too naive, it might be better to put this
into the lower layers (I don't know enough about the library
yet to be sure).
