### PR TITLE
splunk: add missing `defer srv.Close()`

### DIFF
--- a/pkg/splunk/client_test.go
+++ b/pkg/splunk/client_test.go
@@ -54,13 +54,14 @@ func TestSplunkLoggerRetry(t *testing.T) {
 		}
 		ch <- true
 	}))
+	defer srv.Close()
 
 	sl := newSplunkLogger(context.Background(), srv.URL, "token", "source", "hostname", 0)
 	_, err := sl.event([]byte("{}\n"))
 	if err != nil {
 		t.Error(err)
 	}
-	defer sl.close()
+	sl.close()
 
 	if !<-ch {
 		t.Error("timeout")
@@ -95,6 +96,7 @@ func TestSplunkLoggerContext(t *testing.T) {
 		}
 		ch <- true
 	}))
+	defer srv.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	defer cancel()
@@ -103,6 +105,7 @@ func TestSplunkLoggerContext(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	sl.close()
 
 	if !<-ch {
 		t.Error("timeout")


### PR DESCRIPTION
This commit adds missing `defer srv.Close()` in the client tests for splunk. Without that we leave go-routines for the test servers behind. This also closes the splunkLogger when its done (instead of defering it), without that we would close the http server while there is still a connection active. As a side-effect the test runs in 4s for me now instead of 8s.