### PR TITLE
make: run unit tests in non-verbose mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean: ## clean all build and test artifacts
 
 .PHONY: unit-tests
 unit-tests: coverage_data_unittests ## Run all tests with coverage
-	go test -race -v -covermode=atomic ./... -args -test.gocoverdir="$(shell pwd)/coverage_data_unittests"
+	go test -race -covermode=atomic ./... -args -test.gocoverdir="$(shell pwd)/coverage_data_unittests"
 
 .PHONY: test
 test: ## Run tests without coverage


### PR DESCRIPTION
I do not find -v flag too helpful as it pollutes the output with ton of output I usually do not care about. This changes the behavior, particularly useful on CI/CD.

---

@schuellerf since you introduced this, please review.