### PR TITLE
echo: support context passing

### DIFF
--- a/internal/example_web/main.go
+++ b/internal/example_web/main.go
@@ -49,6 +49,12 @@ func startServers(logger *slog.Logger) (*echo.Echo, *echo.Echo, *http.Server) {
 	s1.Logger = echoproxy.NewProxyFor(logger)
 	s1.Use(echo.WrapMiddleware(m1))
 	s1.Use(echo.WrapMiddleware(m3))
+	s1.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			c.SetLogger(echoproxy.NewProxyWithContextFor(logger, c.Request().Context()))
+			return next(c)
+		}
+	})
 	s1.GET("/", func(c echo.Context) error {
 		span, ctx := strc.Start(c.Request().Context(), "s1")
 		defer span.End()

--- a/pkg/collect/buffer_handler.go
+++ b/pkg/collect/buffer_handler.go
@@ -63,6 +63,10 @@ func (h *CollectorHandler) add(m map[string]any) {
 func (h *CollectorHandler) Handle(ctx context.Context, r slog.Record) error {
 	m := make(map[string]any)
 
+	if TestID(ctx) != "" {
+		m["test_id"] = TestID(ctx)
+	}
+
 	m[slog.MessageKey] = r.Message
 
 	if h.addLevel {

--- a/pkg/collect/context.go
+++ b/pkg/collect/context.go
@@ -1,0 +1,27 @@
+package collect
+
+import (
+	"context"
+)
+
+type key int
+
+const (
+	testIDKey key = iota
+)
+
+func WithTestID(ctx context.Context, str string) context.Context {
+	return context.WithValue(ctx, testIDKey, str)
+}
+
+func TestID(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+
+	if v := ctx.Value(testIDKey); v != nil {
+		return v.(string)
+	}
+
+	return ""
+}

--- a/pkg/echo/README.md
+++ b/pkg/echo/README.md
@@ -21,6 +21,28 @@ func main() {
 }
 ```
 
+### Per-request logger
+
+It is possible to set individual echo proxy for each request which performs context passing into every single logging record automatically. Just make sure to put middleware that sets context fields before echo proxy middleware:
+
+```go
+s1 := echo.New()
+s1.Logger = echoproxy.NewProxyFor(slog.Default())
+// strc middleware sets "trace_id" and "request_id"
+s1.Use(echo.WrapMiddleware(strc.NewMiddleware(slog.Default())))
+// pass the context with the fields into echo stack
+s1.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		c.SetLogger(echoproxy.NewProxyContextFor(slog.Default(), c.Request().Context()))
+		return next(c)
+	}
+})
+```
+
+By default, only `trace_id` and `build_id` are logged by the multi handler, this can be customized by providing a callback function via `NewMultiHandlerCustom`.
+
+### Full example
+
 For a full web example run:
 
 ```

--- a/pkg/echo/proxy_test.go
+++ b/pkg/echo/proxy_test.go
@@ -1,6 +1,7 @@
 package echo
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -273,5 +274,23 @@ func TestLogrusProxy(t *testing.T) {
 				t.Errorf("unexpected result: %v expected: %v", result, tt.result)
 			}
 		})
+	}
+}
+
+func TestContext(t *testing.T) {
+	ch := collect.NewTestHandler(slog.LevelDebug, false, false, false)
+	logger := slog.New(ch)
+	ctx := context.Background()
+	ctx = collect.WithTestID(ctx, "test")
+	p := NewProxyWithContextFor(logger, ctx)
+	old := slog.Default()
+	slog.SetDefault(logger)
+	defer slog.SetDefault(old)
+
+	p.Debug("message")
+
+	result := ch.Last()
+	if result["test_id"] != "test" {
+		t.Errorf("context does not pass test_id: %v", result["test_id"])
 	}
 }


### PR DESCRIPTION
The echo logger proxy did not support contexts, therefore it was not possible to create per-request loggers that carry context into the slog handler. With this option, it becomes possible to create loggers that include request-specific information, such as user IDs or request IDs, making it easier to trace logs back to specific requests.

---

This came up during investigating https://github.com/osbuild/logging/issues/37 it does not fix any bug in `logging` but enhances the Echo stack logger capability so CRC can take advantage of that and correlate log records inserted via echo logging: `c.Logger().Info("this message will also have request_id and trace_id automatically")`