### PR TITLE
github: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-*               @osbuild/osbuild-reviewers
+*               @osbuild/logging-reviewers


### PR DESCRIPTION
Switch the code owners to the logging-reviewers team for automatic
review assignment.

@osbuild/logging-reviewers, please take a look.
