### PR TITLE
fix: request filter and tests

### DIFF
--- a/pkg/collect/buffer_handler.go
+++ b/pkg/collect/buffer_handler.go
@@ -186,6 +186,14 @@ func (h *CollectorHandler) All() []map[string]any {
 	return h.data.fields
 }
 
+// Count returns number of all entries that were logged.
+func (h *CollectorHandler) Count() int {
+	h.data.mu.RLock()
+	defer h.data.mu.RUnlock()
+
+	return len(h.data.fields)
+}
+
 // Can be replaced by slices.SortedKeys after Go 1.23+ upgrade
 func sortedKeys[K cmp.Ordered, V any](m map[K]V) []K {
 	keys := make([]K, len(m))

--- a/pkg/strc/middleware_echo.go
+++ b/pkg/strc/middleware_echo.go
@@ -37,7 +37,10 @@ func NewEchoV4MiddlewareWithConfig(logger *slog.Logger, config MiddlewareConfig)
 			// Set per-request logger to the default slog instance with context
 			c.SetLogger(echoproxy.NewProxyWithContextFor(slog.Default(), c.Request().Context()))
 
-			m.before()
+			if !m.before() {
+				// request is not being handled by this middleware
+				return next(c)
+			}
 			defer m.after()
 
 			c.Response().Writer = m.bw

--- a/pkg/strc/middleware_test.go
+++ b/pkg/strc/middleware_test.go
@@ -37,14 +37,7 @@ func TestMiddlewareGenerateContext(t *testing.T) {
 func TestMiddlewareFilter(t *testing.T) {
 	logHandler := collect.NewTestHandler(slog.LevelDebug, false, false, false)
 
-	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-
-		if strc.TraceIDFromContext(ctx) != strc.EmptyTraceID {
-			t.Error("TraceID not set in context")
-		}
-	})
-
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	middleware := strc.NewMiddlewareWithConfig(slog.New(logHandler), strc.MiddlewareConfig{
 		Filters: []strc.Filter{strc.IgnorePathPrefix("/metrics")},
 	})
@@ -52,6 +45,9 @@ func TestMiddlewareFilter(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "http://example.com/metrics", nil)
 	handlerToTest.ServeHTTP(httptest.NewRecorder(), req)
+	if logHandler.Count() != 0 {
+		t.Errorf("Log entries found, expected none: %s", logHandler.All())
+	}
 }
 
 func TestMiddlewareParseContext(t *testing.T) {


### PR DESCRIPTION
The last refactoring of middleware when introducing native echo middleware broke filter. Unfortunately, the unit test was incorrect and did not catch this. This commit fixes the filter logic and the test.

---

Filters are used in CRC to skip logging of some paths:

```go
	s.echo.Pre(strc.NewEchoV4MiddlewareWithConfig(slog.Default(), strc.MiddlewareConfig{
		Filters: []strc.Filter{
			strc.IgnorePathPrefix("/metrics"),
			strc.IgnorePathPrefix("/status"),
			strc.IgnorePathPrefix("/ready"),
		},
	}))
```

