### PR TITLE
strc: propagate echo context

### DIFF
--- a/pkg/strc/middleware_echo.go
+++ b/pkg/strc/middleware_echo.go
@@ -34,14 +34,17 @@ func NewEchoV4MiddlewareWithConfig(logger *slog.Logger, config MiddlewareConfig)
 				},
 			}
 
-			// Set per-request logger to the default slog instance with context
-			c.SetLogger(echoproxy.NewProxyWithContextFor(slog.Default(), c.Request().Context()))
-
 			if !m.before() {
 				// request is not being handled by this middleware
 				return nil
 			}
 			defer m.after()
+
+			// Set the modified context to echo context
+			c.SetRequest(m.r)
+
+			// Set per-request logger to the default slog instance with context
+			c.SetLogger(echoproxy.NewProxyWithContextFor(logger, c.Request().Context()))
 
 			c.Response().Writer = m.bw
 


### PR DESCRIPTION
I have found few problems with the native echo logger that was added recently. It is not working correctly:

* It was called too early, before `before` function which adds the context values
* The context with trace_id/span_id values was never put back into echo context via `SetRequest`
* It was using `slog.Default()` global logger while logger passed in as argument should be used (which improves testability)
* There was no test for this

Since you already have a nice refactoring, would you mind taking the tiny change and the test into your PR, @croissanne? Alternatively, I can wait until yours is merged and rebase on top of that.