### PR TITLE
many: update deps, fix TracingDoer and spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ go run github.com/osbuild/logging/internal/example_cli/
 
 See [strc](pkg/strc) source or [package documentation](https://pkg.go.dev/github.com/osbuild/logging/pkg/strc) for more info.
 
-The generated SVG file is interactive and one can drill down the stack with a mouse click, the file needs to be opened in a new browser panel tho:
+The generated SVG file is interactive and one can drill down the stack with a mouse click, the file needs to be opened in a new browser panel though:
 
 [![Example](pkg/strc/stgraph/graph.svg)](pkg/strc/stgraph/graph.svg)
 
@@ -210,7 +210,7 @@ msg="span http client request started" span.name="http client request" span.id=c
 
 Note that the "slog msg" entry also contains `trace_id` key in the root namespace. This key is automatically added by the `MultiHandler` for all log messages for correlation purposes. It also adds `build_id` with git sha, but this was disabled for the example output for better readability as well as Go source location information. Also note `trace_id` is missing from logrus and echo proxies as the API does not support passing of context into log records. These proxies are meant as a temporary solution until all log statements are rewritten to `log/slog`.
 
-Service 2 is another echo code that is more straightforward - it simply calls service 3:
+Service 2 is another echo app that is more straightforward - it simply calls service 3:
 
 ```
 span, ctx := strc.Start(c.Request().Context(), "s2")
@@ -247,7 +247,7 @@ msg="span subProcess finished in 113.019µs" span.name=subProcess span.id=XeJUmb
 msg="span s3 finished in 1.02967ms" span.name=s3 span.id=xJmKjiw span.parent=bcoxtVq span.trace=iggIwgmkOVigBFV span.dur=1.02967ms
 ```
 
-Since the applications also have Echo middleware enabled which creates INFO level messages for each request, a detailed HTTP request/response appears in logs to and HTTP client and handler spans are concluded as well:
+Since the applications also have Echo middleware enabled which creates INFO level messages for each request, a detailed HTTP request/response appears in logs, and HTTP client and handler spans are concluded as well:
 
 ```
 msg="200: OK" request.method=GET request.host=localhost:8133 request.path=/ request.ip=[::1]:35934 request.length=0 request.body="" request.header.X-Strc-Trace-Id=[iggIwgmkOVigBFV] request.header.Accept-Encoding=[gzip] request.header.User-Agent=[Go-http-client/1.1] request.header.X-Strc-Span-Id=[buakavZ.bcoxtVq] request.user-agent=Go-http-client/1.1 response.latency=1.063409ms response.status=200 response.length=0 response.body="" trace_id=iggIwgmkOVigBFV

--- a/pkg/collect/package.go
+++ b/pkg/collect/package.go
@@ -1,2 +1,2 @@
-// Collecting log/slog handler, usefull for testing.
+// Collecting log/slog handler, useful for testing.
 package collect

--- a/pkg/echo/README.md
+++ b/pkg/echo/README.md
@@ -1,6 +1,6 @@
 ## echo
 
-A temporary `echo` proxy to `log/slog`. Only used for the transition period until our projects are fully migrated. Please keep in mind this is an incomplete implementation, only functions used in osbuild project are present.
+A temporary `echo` proxy to `log/slog`. Only used for the transition period until our projects are fully migrated. Please keep in mind this is an incomplete implementation, only functions used in osbuild projects are present.
 
 ### How to use
 

--- a/pkg/echo/proxy.go
+++ b/pkg/echo/proxy.go
@@ -11,7 +11,7 @@ import (
 	"github.com/labstack/gommon/log"
 )
 
-// Proxy is a proxy type for logrus.Logger
+// Proxy is a proxy type for echo.Logger
 type Proxy struct {
 	dest *slog.Logger
 	ctx  context.Context

--- a/pkg/sinit/init.go
+++ b/pkg/sinit/init.go
@@ -157,7 +157,7 @@ var (
 	res   *resources
 	resMu sync.Mutex
 
-	ErrAlreadyInitialized   = errors.New("logging already initialized, call Close clean")
+	ErrAlreadyInitialized   = errors.New("logging already initialized, call Close to clean up")
 	ErrInvalidURL           = errors.New("invalid URL")
 	ErrMissingURL           = errors.New("missing URL")
 	ErrSentryInitialization = errors.New("sentry initialization error")

--- a/pkg/splunk/handler.go
+++ b/pkg/splunk/handler.go
@@ -102,7 +102,7 @@ func (h *SplunkHandler) Enabled(ctx context.Context, level slog.Level) bool {
 func (h *SplunkHandler) Handle(ctx context.Context, r slog.Record) error {
 	err := h.jh.Handle(ctx, r)
 
-	// Since errors are silently ignored in slog, let's make an good will attempt.
+	// Since errors are silently ignored in slog, let's make a good faith attempt.
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "splunk handler error: %v\n", err)
 	}

--- a/pkg/strc/context.go
+++ b/pkg/strc/context.go
@@ -40,7 +40,7 @@ func NewTraceID() TraceID {
 	return TraceID(randString(traceLength))
 }
 
-// SpanID is a unique identifier for a trace.
+// SpanID is a unique identifier for a span.
 type SpanID string
 
 func (s SpanID) String() string {
@@ -64,7 +64,7 @@ func NewSpanID(ctx context.Context) SpanID {
 	return SpanID(SpanIDFromContext(ctx).ID() + "." + randString(spanLength))
 }
 
-// Start returns trace ID from a context. It returns EmptyTraceID if trace ID is not found.
+// TraceIDFromContext returns trace ID from a context. It returns EmptyTraceID if trace ID is not found.
 // Use NewTraceID to generate a new trace ID.
 func TraceIDFromContext(ctx context.Context) TraceID {
 	if ctx == nil {
@@ -78,7 +78,7 @@ func TraceIDFromContext(ctx context.Context) TraceID {
 	return EmptyTraceID
 }
 
-// Start returns a new context with trace ID.
+// WithTraceID returns a new context with trace ID.
 func WithTraceID(ctx context.Context, traceID TraceID) context.Context {
 	return context.WithValue(ctx, traceIDKey, traceID)
 }
@@ -101,7 +101,7 @@ func AddTraceIDHeader(ctx context.Context, req *http.Request) {
 	}
 }
 
-// Start returns span ID from a context. It returns EmptySpanID if span ID is not found.
+// SpanIDFromContext returns span ID from a context. It returns EmptySpanID if span ID is not found.
 // Use NewSpanID to generate a new span ID.
 func SpanIDFromContext(ctx context.Context) SpanID {
 	if ctx == nil {
@@ -115,12 +115,12 @@ func SpanIDFromContext(ctx context.Context) SpanID {
 	return EmptySpanID
 }
 
-// Start returns a new context with span ID.
+// WithSpanID returns a new context with span ID.
 func WithSpanID(ctx context.Context, spanID SpanID) context.Context {
 	return context.WithValue(ctx, spanIDKey, spanID)
 }
 
-// Start returns span from a context or nil if it was not found.
+// SpanFromContext returns span from a context or nil if it was not found.
 func SpanFromContext(ctx context.Context) *Span {
 	if ctx == nil {
 		return nil
@@ -133,7 +133,7 @@ func SpanFromContext(ctx context.Context) *Span {
 	return nil
 }
 
-// Start returns a new context with span.
+// WithSpan returns a new context with span.
 func WithSpan(ctx context.Context, span *Span) context.Context {
 	return context.WithValue(ctx, spanKey, span)
 }

--- a/pkg/strc/doer.go
+++ b/pkg/strc/doer.go
@@ -104,10 +104,10 @@ func (td *TracingDoer) Do(req *http.Request) (*http.Response, error) {
 		return nil, NewDoerErr(err)
 	}
 
-	// dump request body if enabled
+	// dump response body if enabled
 	if td.config.WithResponseBody && res.Body != nil {
-		br := newBodyReader(req.Body, ResponseBodyMaxSize, td.config.WithRequestBody)
-		req.Body = br
+		br := newBodyReader(res.Body, ResponseBodyMaxSize, td.config.WithResponseBody)
+		res.Body = br
 
 		logger.WithGroup("response").With(
 			slog.Int64("length", res.ContentLength),

--- a/pkg/strc/doer_test.go
+++ b/pkg/strc/doer_test.go
@@ -1,0 +1,139 @@
+package strc
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestTracingDoerBodyDumping(t *testing.T) {
+	tests := []struct {
+		name         string
+		config       TracingDoerConfig
+		reqBody      string
+		respBody     string
+		wantReqBody  string
+		wantRespBody string
+	}{
+		{
+			name:         "request body only",
+			config:       TracingDoerConfig{WithRequestBody: true},
+			reqBody:      "request data",
+			respBody:     "response data",
+			wantReqBody:  "request data",
+			wantRespBody: "response data",
+		},
+		{
+			name:         "response body only",
+			config:       TracingDoerConfig{WithResponseBody: true},
+			reqBody:      "request data",
+			respBody:     "response data",
+			wantReqBody:  "request data",
+			wantRespBody: "response data",
+		},
+		{
+			name: "both bodies",
+			config: TracingDoerConfig{
+				WithRequestBody:  true,
+				WithResponseBody: true,
+			},
+			reqBody:      "request data",
+			respBody:     "response data",
+			wantReqBody:  "request data",
+			wantRespBody: "response data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				if string(body) != tt.wantReqBody {
+					t.Errorf("server received body = %q, want %q", string(body), tt.wantReqBody)
+				}
+				w.Write([]byte(tt.respBody))
+			}))
+			defer server.Close()
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			slog.SetDefault(logger)
+			SetLogger(logger)
+
+			doer := NewTracingDoerWithConfig(server.Client(), tt.config)
+			req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, server.URL, strings.NewReader(tt.reqBody))
+
+			resp, err := doer.Do(req)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			defer resp.Body.Close()
+
+			body, _ := io.ReadAll(resp.Body)
+			if string(body) != tt.wantRespBody {
+				t.Errorf("response body = %q, want %q", string(body), tt.wantRespBody)
+			}
+		})
+	}
+}
+
+func TestTracingDoerHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(TraceHTTPHeaderName) == "" {
+			t.Error("trace header not set")
+		}
+		if r.Header.Get(SpanHTTPHeaderName) == "" {
+			t.Error("span header not set")
+		}
+		w.Header().Set("X-Custom", "value")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	slog.SetDefault(logger)
+	SetLogger(logger)
+
+	ctx := WithTraceID(context.Background(), NewTraceID())
+	doer := NewTracingDoer(server.Client())
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+	resp, err := doer.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.Header.Get("X-Custom") != "value" {
+		t.Error("custom header not found in response")
+	}
+}
+
+func TestTracingDoerError(t *testing.T) {
+	doer := NewTracingDoer(&errorDoer{})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
+
+	_, err := doer.Do(req)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var doerErr *DoerErr
+	if !errors.As(err, &doerErr) {
+		t.Errorf("error should be DoerErr, got %T", err)
+	}
+
+	if !errors.Is(err, http.ErrAbortHandler) {
+		t.Error("should be able to unwrap to original error")
+	}
+}
+
+type errorDoer struct{}
+
+func (d *errorDoer) Do(req *http.Request) (*http.Response, error) {
+	return nil, http.ErrAbortHandler
+}

--- a/pkg/strc/multi_test.go
+++ b/pkg/strc/multi_test.go
@@ -122,3 +122,32 @@ func TestMultiCustomValuesSlogtest(t *testing.T) {
 		}
 	}
 }
+
+func TestMultiTraceID(t *testing.T) {
+	ctx := strc.WithTraceID(context.Background(), strc.NewTraceID())
+
+	testMultiCallback := func(ctx context.Context, a []slog.Attr) ([]slog.Attr, error) {
+		return append(a, slog.String("callback", "value")), nil
+	}
+
+	var buf bytes.Buffer
+	hj := slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+	h := strc.NewMultiHandlerCustom([]slog.Attr{slog.String("static", "value")}, testMultiCallback, hj)
+	logger := slog.New(h)
+
+	logger.DebugContext(ctx, "test")
+
+	if !strings.Contains(buf.String(), `"static":"value"`) {
+		t.Errorf("missing static attribute: %s", buf.String())
+	}
+
+	if !strings.Contains(buf.String(), `"callback":"value"`) {
+		t.Errorf("missing callback attribute: %s", buf.String())
+	}
+
+	if !strings.Contains(buf.String(), `"trace_id":`) {
+		t.Errorf("missing trace_id attribute: %s", buf.String())
+	}
+}

--- a/pkg/strc/stgraph/README.md
+++ b/pkg/strc/stgraph/README.md
@@ -38,7 +38,7 @@ Then install flamegraph utility (package for Fedora available) and run:
 flamegraph.pl /tmp/graph.unfolded > graph.svg
 ```
 
-The generated SVG file is interactive and one can drill down the stack with a mouse click, the file needs to be opened in a new browser panel tho:
+The generated SVG file is interactive and one can drill down the stack with a mouse click, the file needs to be opened in a new browser panel though:
 
 [![Example](graph.svg)](graph.svg)
 

--- a/pkg/strc/trace.go
+++ b/pkg/strc/trace.go
@@ -18,10 +18,10 @@ var SpanGroupName string = "span"
 // TraceIDName is the key name used for trace ID.
 var TraceIDName string = "trace"
 
-// SpanIDName is the key name used for trace ID.
+// SpanIDName is the key name used for span ID.
 var SpanIDName string = "id"
 
-// ParentIDName is the key name used for trace ID.
+// ParentIDName is the key name used for parent ID.
 var ParentIDName string = "parent"
 
 // SkipSource is a flag that disables source logging.


### PR DESCRIPTION
Several minor changes, I just wanted to update deps while keeping 1.24 Go version we use in CRC.

Claude noticed that the TracingDoer was not working correctly, it was a typo where response dumping was actually dumping request data. A test was added for this debug doer.